### PR TITLE
Fix #1 - Service starting despite being disabled

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/src/main/java/xyz/codingindex/autolockdown/AutoStartReceiver.kt
+++ b/app/src/main/java/xyz/codingindex/autolockdown/AutoStartReceiver.kt
@@ -8,17 +8,24 @@ import android.content.Intent
 
 class AutoStartReceiver : BroadcastReceiver() {
 
+    fun isEnabled(context: Context): Boolean {
+        return context
+            .getSharedPreferences(context.getString(R.string.ald_sp_key), Context.MODE_PRIVATE)
+            .getBoolean("enabled", false)
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
-        (context.getSystemService(Context.ALARM_SERVICE) as AlarmManager).also { am ->
-            am.setInexactRepeating(
-                AlarmManager.RTC_WAKEUP,
-                System.currentTimeMillis() + 100,
-                100,
-                PendingIntent.getForegroundService(
-                    context, 0, Intent(context, ScreenStatusService::class.java),
-                    PendingIntent.FLAG_UPDATE_CURRENT
+        if (isEnabled(context)) {
+            (context.getSystemService(Context.ALARM_SERVICE) as AlarmManager).also { am ->
+                am.set(
+                    AlarmManager.RTC_WAKEUP,
+                    System.currentTimeMillis() + 100,
+                    PendingIntent.getForegroundService(
+                        context, 0, Intent(context, ScreenStatusService::class.java),
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    )
                 )
-            )
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds checks to ensure that `BootReceiver` doesn't launch the service at start if service is disabled
- Make the `PendingIntent` for the service be triggered by the alarm only once