### PR TITLE
Fix issues #2, #3

### DIFF
--- a/app/src/main/java/xyz/codingindex/autolockdown/AutoLockdownTileService.kt
+++ b/app/src/main/java/xyz/codingindex/autolockdown/AutoLockdownTileService.kt
@@ -36,11 +36,19 @@ class AutoLockdownTileService : TileService() {
     override fun onClick() {
         super.onClick()
 
-        if (this.qsTile.state == Tile.STATE_ACTIVE) {
-            this.setEnabled(false)
-        } else {
-            this.setEnabled(true)
-            startForegroundService(Intent(applicationContext, ScreenStatusService::class.java))
+        Runnable {
+            if (this.qsTile.state == Tile.STATE_ACTIVE) {
+                this.setEnabled(false)
+            } else {
+                this.setEnabled(true)
+                startForegroundService(Intent(applicationContext, ScreenStatusService::class.java))
+            }
+        }.also { runnable ->
+            if (this.isLocked) {
+                this.unlockAndRun(runnable)
+            } else {
+                runnable.run()
+            }
         }
     }
 


### PR DESCRIPTION
- Autolockdown can now only be disabled from the quick settings tile when the phone is unlocked
- Added logic to synchronize between service state, "enabled" status in settings activity, and the Quick Tile
- Moved service launching code from the Settings activity into the `SettingsFragment` instead on the root activity